### PR TITLE
Fixes for now-deprecated `tflite_flutter_helper`

### DIFF
--- a/android/src/main/kotlin/com/tfliteflutter/tflite_flutter_helper/TfliteFlutterHelperPlugin.kt
+++ b/android/src/main/kotlin/com/tfliteflutter/tflite_flutter_helper/TfliteFlutterHelperPlugin.kt
@@ -140,14 +140,14 @@ class TfliteFlutterHelperPlugin : FlutterPlugin,
 		}
 	}
 
-	override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?,
-											grantResults: IntArray?): Boolean {
+	override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>,
+											grantResults: IntArray): Boolean {
 		when (requestCode) {
 			AUDIO_RECORD_PERMISSION_CODE -> {
-				if (grantResults != null) {
-					permissionToRecordAudio = grantResults.isNotEmpty() &&
-							grantResults[0] == PackageManager.PERMISSION_GRANTED
-				}
+
+				permissionToRecordAudio = grantResults.isNotEmpty() &&
+						grantResults[0] == PackageManager.PERMISSION_GRANTED
+
 				completeInitializeRecorder()
 				return true
 			}


### PR DESCRIPTION
- Upgrade onRequestPermissionsResult parameters for Android 
- Upgrade ffi to ^2.0.0 in order to be aligned with transitive dependencies for other apps